### PR TITLE
Fix pattern mismatch for AWS::AppSync::FunctionConfiguration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,6 @@ class TypeSpec {
 
     /**
      * generates resource name based on the given prefix and logical name
-     * generates resource name based on the given prefix and logical name
      * @param prefix
      * @param logicalName
      * @returns {*}

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class TypeSpec {
 
     /**
      * generates resource name based on the given prefix and logical name
+     * generates resource name based on the given prefix and logical name
      * @param prefix
      * @param logicalName
      * @returns {*}
@@ -126,7 +127,7 @@ const typeSpecs = [
 
     // AppSync
     new TypeSpec(new TypeID("AWS", "AppSync", "DataSource"), { namePropIncludesTypeName: false, nameConverter: val => val.replace(/-/g, "_") }),
-    new TypeSpec(new TypeID("AWS", "AppSync", "FunctionConfiguration"), { namePropIncludesTypeName: false }),
+    new TypeSpec(new TypeID("AWS", "AppSync", "FunctionConfiguration"), { namePropIncludesTypeName: false, nameConverter: val => val.replace(/-/g, "_") }),
     new TypeSpec(new TypeID("AWS", "AppSync", "GraphQLApi"), { namePropIncludesTypeName: false }),
 
     // CloudWatch Logs


### PR DESCRIPTION
Pattern for Name of [FunctionConfiguration](https://docs.aws.amazon.com/appsync/latest/APIReference/API_FunctionConfiguration.html) is [_A-Za-z][_0-9A-Za-z]*.
Stack creations with - (45) complete successfully but updates do not.